### PR TITLE
Check PHP max version compatibility

### DIFF
--- a/phppsinfo.php
+++ b/phppsinfo.php
@@ -111,6 +111,12 @@ class PhpPsInfo
         ],
     ];
 
+    protected $incompatibility = [
+		'versions' => [
+			'php' => '8.2',
+		]
+	];
+
     /**
      * Set up login and password with parameter or
      * you can set server env vars:
@@ -177,9 +183,11 @@ class PhpPsInfo
             $this->requirements['versions']['php'],
             $this->recommended['versions']['php'],
             PHP_VERSION,
-            version_compare(PHP_VERSION, $this->recommended['versions']['php'], '>=') ?
-            self::TYPE_OK : (
-                version_compare(PHP_VERSION, $this->requirements['versions']['php'], '>=') ?
+            version_compare(PHP_VERSION, $this->recommended['versions']['php'], '>=') &&
+            version_compare(PHP_VERSION, $this->incompatibility['versions']['php'], '<') ?
+                self::TYPE_OK : (
+            version_compare(PHP_VERSION, $this->requirements['versions']['php'], '>=') &&
+            version_compare(PHP_VERSION, $this->incompatibility['versions']['php'], '<') ?
                 self::TYPE_WARNING :
                 self::TYPE_ERROR
             )


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a way to check if a PHP version can be too new for PrestaShop
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #32
| How to test?      | PHP version ≥8.2 must display a cell with red background

Tests :

PHP 8.2 is incompatible:
![php_8 2](https://github.com/PrestaShop/php-ps-info/assets/7419525/ef0e8b72-6e33-48ea-954c-e5c3d51f6847)

PHP 8.1 is OK:
![php_8 1](https://github.com/PrestaShop/php-ps-info/assets/7419525/f7bfca5d-0d60-428b-826a-9143ac1f086d)

PHP 7.4 is required but not recommended:
![php_7 4](https://github.com/PrestaShop/php-ps-info/assets/7419525/a7bcb84d-06cf-451e-bd4e-0600a2383b57)
